### PR TITLE
Dash_27 NuxtとVueの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ pgadmin
 phpmyadmin
 work
 container/php/log
+src/frontend/*
 .DS_Store

--- a/container/front/Dockerfile
+++ b/container/front/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+
+WORKDIR /var/www/nuxt
+
+RUN apk update && \
+    apk add git curl && \
+    yarn global add create-nuxt-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,5 +54,19 @@ services:
       PGADMIN_DEFAULT_PASSWORD: pass
     depends_on:
       - db1
+  front:
+    # container_name: "laravel"
+    build:
+      dockerfile: "./container/front/Dockerfile"
+    ports:
+      - "3000:3000"
+    volumes:
+      - "./src/frontend:/var/www/nuxt"
+      - node_modules_volume:/src/node_modules
+    tty: true
+    environment:
+      - HOST=0.0.0.0
+      - CHOKIDAR_USEPOLLING=true
 volumes: # 追加
   vendor: # 追加
+  node_modules_volume:


### PR DESCRIPTION
## 対応チケット
[Dash_27 NuxtとVueの導入](https://gonzuiswimmer.atlassian.net/browse/DASH-27)

## やったこと
- `docker_compose.yml`を編集し、frontコンテナを作成
- `./container/front/Dockerfile`を作成し、node18のイメージをインストール
- `npx nuxi init`でnuxt@3^をインストール
- `npm run dev`で初期画面が表示されることを確認

## 動作確認
- バージョン情報
    * node v18.19.0
    * npm 10.2.3
    * nuxt 3.8.2
    * vue 3.3
- 画面キャプチャなど
<img width="782" alt="image" src="https://github.com/gonzuiswimmer/dash_replace2/assets/115978255/42a55148-8666-4b36-b9e8-4d15c0b5716a">


## その他
### バージョン選定理由
#### Nuxt
* Nuxt2が2023年12月末でサポートが終了するため、Nuxt3でインストール
* Vue3^に対応するため
#### Vue
* Vue2が2023年12月末でサポート終了するため
* Vue3の経験があり、その知見を活かすため
#### node/npm
* 上記のバージョンに対応するため
