### PR TITLE
DASH_27 Nuxtバージョンおよびdockerfileのダウングレード

### DIFF
--- a/container/front/Dockerfile
+++ b/container/front/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:14-alpine
 
 WORKDIR /var/www/nuxt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - "3000:3000"
     volumes:
       - "./src/frontend:/var/www/nuxt"
-      - node_modules_volume:/src/node_modules
+      - node_modules_volume:/src/frontend/node_modules
     tty: true
     environment:
       - HOST=0.0.0.0


### PR DESCRIPTION
## 対応チケット
[Dash_27 NuxtとVueの導入](https://gonzuiswimmer.atlassian.net/browse/DASH-27)

## やったこと
- `docker_compose.yml`を編集し、frontコンテナを作成
- `./container/front/Dockerfile`を作成し、node14のイメージをインストール
- `npm run dev`で初期画面が表示されることを確認

## 動作確認
- バージョン情報
    * node vv14.21.3
    * npm 6.14.18
    * nuxt@2.17.2
    * vue@2.7.15
- 画面キャプチャなど
<img width="746" alt="image" src="https://github.com/gonzuiswimmer/dash_replace2/assets/115978255/15c20e68-0b2f-4832-8186-a66f8be51e2f">



## その他
### バージョン選定理由
#### Nuxt
* 開発時点でLTSであるNuxt2を選定（Nuxt2が2023年12月末まで）
* Nuxt2の操作経験があり、ドキュメントや参考記事が豊富なため
#### Vue
* 上記のバージョンに対応するため
#### node/npm
* 上記のバージョンに対応するため
